### PR TITLE
sigmoid_derivative() should accept training input

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -22,7 +22,7 @@ class NeuralNetwork():
     # This is the gradient of the Sigmoid curve.
     # It indicates how confident we are about the existing weight.
     def __sigmoid_derivative(self, x):
-        sigmoid_x = self.__sigmoid(x)
+        sigmoid_x = self.__sigmoid(dot(x, self.synaptic_weights))
         return sigmoid_x * (1 - sigmoid_x)
 
     # We train the neural network through a process of trial and error.
@@ -39,7 +39,7 @@ class NeuralNetwork():
             # Multiply the error by the input and again by the gradient of the Sigmoid curve.
             # This means less confident weights are adjusted more.
             # This means inputs, which are zero, do not cause changes to the weights.
-            adjustment = dot(training_set_inputs.T, error * self.__sigmoid_derivative(output))
+            adjustment = dot(training_set_inputs.T, error * self.__sigmoid_derivative(training_set_inputs))
 
             # Adjust the weights.
             self.synaptic_weights += adjustment


### PR DESCRIPTION
The issue mentioned in main repo https://github.com/llSourcell/Make_a_neural_network/issues/1, was a misunderstanding, or more about the code looks confusing with the name *sigmoid_derivative*

The code looks more readable with your update.
But I wan't to point out this issue, Sigmoid derivate should accept the input training set only.